### PR TITLE
drv_mellanox.cc: typo

### DIFF
--- a/drv_mellanox.cc
+++ b/drv_mellanox.cc
@@ -11,7 +11,7 @@
 
 #include "parser.h"
 
-static RegexParser mellaonx_mlx5_core( 
+static RegexParser mellanox_mlx5_core( 
 	{ "mlx5_core" },
 	{ "^(rx|tx)_(bytes|packets)$", { 1, 2} },
 	{ "^(rx|tx)(\\d+)_(?:0_)?(bytes|packets)$", { 1, 3, 2 } }


### PR DESCRIPTION
Correct typo in the drv_mellanox.cc file