### PR TITLE
Add tinfo to linking. Current Linux outputs -lncurses -ltinfo in pkgconfig for ncurses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CXXFLAGS	= -O3 -std=c++11 -Wall -Werror
 
 LDFLAGS		= -s
 
-LIBS_CURSES	= -lncurses
+LIBS_CURSES	= -lncurses -ltinfo
 
 TARGETS		= ethq ethq_test
 


### PR DESCRIPTION
When compiling on current system (Debian 10, Fedora 33, Ubuntu 18.04), I encountered problem:
```
c++ -o ethq ethq.o ethtool++.o interface.o parser.o util.o drv_generic.o drv_bcm.o drv_emulex.o drv_intel.o drv_mellanox.o drv_amazon.o drv_virtio.o drv_vmware.o -O3 -std=c++11 -Wall -Werror -s -lncurses
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: ethq.o: undefined reference to symbol 'nodelay'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /lib64/libtinfo.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
Adding tinfo resolves linking issue.